### PR TITLE
相対カテゴリを指定可能にした

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,14 @@ module.exports = {
         // Search queary (optional)
         // See :y https://docs.esa.io/posts/104
         // Example : 'in:public'  or 'wip:false in:public'
-        q: ``
+        q: '',
+        // Relative Category (optional)
+        // Example: 'public'
+        // {
+        //   category: 'public/gatsby',
+        //   relative_category: 'gatsby',
+        // }
+        baseCategory: ''
       }
     }
   ]
@@ -41,6 +48,10 @@ module.exports = {
         number
         name
         body_md
+        body_html
+        category
+        relative_category
+        tags
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-esa",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "description": "Gatsby source plugin for building websites using esa.io as a data source.",
   "main": "gatsby-node.js",
   "scripts": {

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -7,26 +7,9 @@ exports.sourceNodes = async ({
 }, {
   accessToken,
   teamName,
+  baseCategory = '',
   q = ''
 }) => {
-  const createNodeFromPost = post => {
-    const contentDigest = crypto
-      .createHash(`md5`)
-      .update(JSON.stringify(post))
-      .digest('hex')
-    const baseNode = {
-      id: createNodeId(`EsaPost${post.number}`),
-      children: [],
-      parent: `__SOURCE__`,
-      internal: {
-        type: 'EsaPost',
-        contentDigest,
-      }
-    }
-
-    boundActionCreators.createNode(Object.assign({}, baseNode, post))
-  }
-
   if (!accessToken) {
     throw 'You need to set an accessToken.'
   }
@@ -50,7 +33,25 @@ exports.sourceNodes = async ({
       }
     })
 
-    body.posts.forEach(post => createNodeFromPost(post))
+    body.posts.forEach(post => {
+      const contentDigest = crypto
+        .createHash(`md5`)
+        .update(JSON.stringify(post))
+        .digest('hex')
+
+      boundActionCreators.createNode({
+        ...post,
+        relative_category: post.category.replace(new RegExp(`${baseCategory}/?`), ''),
+        id: createNodeId(`EsaPost${post.number}`),
+        children: [],
+        parent: `__SOURCE__`,
+        internal: {
+          type: 'EsaPost',
+          contentDigest,
+        }
+      })
+    })
+
     next_page = body.next_page
   }
 


### PR DESCRIPTION
`v.1.1.0`
gatsby-config.jsのoptionsに`baseCategory`を渡すと相対的なカテゴリを`relative_category`として返すようにした。

```
baseCategory: 'blog' と指定した場合

category: 'blog/event'
relative_category: 'event'
```

<img width="551" alt="2018-10-13 17 25 08" src="https://user-images.githubusercontent.com/7007253/46903251-4a20fb00-cf0d-11e8-9aba-1c903aeb4897.png">
